### PR TITLE
Fix 'all substrates' test selection

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -22,7 +22,7 @@ launchpad.api.url = https://api.launchpad.net/1.0
 
 # 86400 = one day, in seconds
 testing.timeout = 86400
-testing.substrates = aws,azure,hp,joyent,lxc
+testing.substrates = aws,azure,hp,joyent,lxc,power8
 testing.default_substrates = lxc
 testing.jenkins_url = http://juju-ci.vapour.ws:8080/job/charm-bundle-test-wip/buildWithParameters
 testing.jenkins_token = 9db37b978a6683a60a861e1c3392c26f5c356837

--- a/reviewq/models.py
+++ b/reviewq/models.py
@@ -87,6 +87,11 @@ class Review(Base):
                          backref=backref('reviews'))
     locker = relationship('User', foreign_keys=[lock_id],
                           backref=backref('locks'))
+    tests = relationship(
+        'ReviewTest',
+        backref=backref('review'),
+        order_by="desc(ReviewTest.updated)"
+    )
 
     def get_test_url(self):
         if self.test_url:
@@ -280,11 +285,6 @@ class ReviewTest(Base):
                      onupdate=datetime.datetime.utcnow)
     finished = Column(UTCDateTime)
 
-    review = relationship(
-        'Review',
-        backref=backref('tests'),
-        order_by="ReviewTest.id"
-    )
     requester = relationship('User')
 
     def send_ci_request(self, settings):

--- a/reviewq/plugins/launchpad.py
+++ b/reviewq/plugins/launchpad.py
@@ -174,13 +174,18 @@ class LaunchPad(SourcePlugin):
     @wait_a_second
     def create_from_bug(self, task):
         bug = task.bug
+        test_url = (
+            bug.linked_branches[0].branch.bzr_identity
+            if bug.linked_branches
+            else None
+        )
         with transaction.manager:
             r = Review.get(api_url=task.self_link)
             if not r:
                 r = Review(
                     type='NEW',
                     api_url=task.self_link,
-                    test_url=bug.linked_branches[0].branch.bzr_identity,
+                    test_url=test_url,
                     created=task.date_created.replace(tzinfo=None)
                 )
                 r.source = Source.get(slug='lp')
@@ -193,7 +198,7 @@ class LaunchPad(SourcePlugin):
             r.title = bug.title
             r.owner = create_user(task.owner)
             r.url = task.web_link
-            r.test_url = bug.linked_branches[0].branch.bzr_identity
+            r.test_url = test_url
             r.syncd = datetime.datetime.utcnow()
             state = bug_state(task)
             updated = (

--- a/reviewq/tasks.py
+++ b/reviewq/tasks.py
@@ -90,7 +90,8 @@ def update_lp_item(self, rt):
     if content and asbool(celery.settings.get('testing.comments')):
         subject = (
             '%s Test Results: %s' % (
-                rt.substrate.upper(), rt.review.title))
+                (rt.substrate or '').upper(),
+                rt.review.title))
 
         if hasattr(item, 'createComment'):
             # It's a merge request

--- a/reviewq/views.py
+++ b/reviewq/views.py
@@ -217,7 +217,11 @@ def test_review(request):
         return HTTPNotFound()
 
     substrate = request.params.get('substrate')
-    substrate = None if substrate == 'all' else [substrate]
+    substrate = (
+        request.registry.settings['testing.substrates'].split(',')
+        if substrate == 'all'
+        else [substrate]
+    )
 
     review.create_tests(
         request.registry.settings, substrates=substrate)


### PR DESCRIPTION
When you click All, actually run it on all, instead of just
the default substrates, which are what's used when launching
tests post-ingestion.
