### PR TITLE
Use `juju-solutions` namespace in footer links

### DIFF
--- a/reviewq/templates/main.pt
+++ b/reviewq/templates/main.pt
@@ -63,8 +63,8 @@
     <div class="ten wide column center">
       <div class="center">
         Made with <i class="icon github alternative"></i>
-        <a href="https://github.com/marcoceppi/review-queue">love</a>.
-        <i class="icon bug"></i>Bugs? <a href="https://github.com/marcoceppi/review-queue">Never!</a>
+        <a href="https://github.com/juju-solutions/review-queue">love</a>.
+        <i class="icon bug"></i>Bugs? <a href="https://github.com/juju-solutions/review-queue/issues">Never!</a>
       </div>
     </div>
     <div class="three wide column right">


### PR DESCRIPTION
This change replaces `marcoceppi` namespace with `juju-solutions` from
the links placed at the footer of the main template.

Fixes #30
